### PR TITLE
Changes necessary for empty views

### DIFF
--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -66,9 +66,15 @@ jacoco {
     toolVersion = "0.7.1.201405082137"
 }
 
-def coverageSourceDirs = [
-    'src/main/java'
-]
+def coverageSourceDirs = ['src/main/java']
+def coverageExclusions = ['**/R.class',
+                          '**/R$*.class',
+                          '**/*$ViewInjector*.*',
+                          '**/BuildConfig.*',
+                          '**/Manifest*.*',
+                          '**/CameraPreview*.*',
+                          '**/MediaSourceCaptureImage*.*',
+                          '**/MediaSourceCaptureImage*.*']
 
 task jacocoTestReport(type: JacocoReport, dependsOn: "testDebug") {
     group = "Reporting"
@@ -76,11 +82,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: "testDebug") {
 
     classDirectories = fileTree(
             dir: 'build/intermediates/classes/debug',
-            excludes: ['**/R.class',
-                       '**/R$*.class',
-                       '**/*$ViewInjector*.*',
-                       '**/BuildConfig.*',
-                       '**/Manifest*.*']
+            excludes: coverageExclusions
     )
 
     additionalSourceDirs = files(coverageSourceDirs)

--- a/mediapicker/src/androidTest/java/org/wordpress/mediapicker/MediaPickerFragmentTest.java
+++ b/mediapicker/src/androidTest/java/org/wordpress/mediapicker/MediaPickerFragmentTest.java
@@ -1,6 +1,7 @@
 package org.wordpress.mediapicker;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Parcel;
 import android.support.v4.app.FragmentActivity;
 import android.view.ActionMode;
@@ -123,7 +124,7 @@ public class MediaPickerFragmentTest {
 
     private MediaSource mMediaSourceOnMediaSelectedFalse = new MediaSource() {
         @Override
-        public void gather() {
+        public void gather(Context context) {
         }
 
         @Override

--- a/mediapicker/src/androidTest/java/org/wordpress/mediapicker/MediaSourceAdapterTest.java
+++ b/mediapicker/src/androidTest/java/org/wordpress/mediapicker/MediaSourceAdapterTest.java
@@ -45,7 +45,7 @@ public class MediaSourceAdapterTest {
     @Test
     public void testViewTypeCountWithOneSource() {
         final ArrayList<MediaSource> testSources = new ArrayList<>();
-        testSources.add(new MediaSourceDeviceImages(mock(ContentResolver.class)));
+        testSources.add(new MediaSourceDeviceImages());
 
         final MediaSourceAdapter testAdapter = new MediaSourceAdapter(Robolectric.application, testSources, null);
 
@@ -58,8 +58,8 @@ public class MediaSourceAdapterTest {
     @Test
     public void testViewTypeCountWithManySources() {
         final ArrayList<MediaSource> testSources = new ArrayList<>();
-        testSources.add(new MediaSourceDeviceImages(mock(ContentResolver.class)));
-        testSources.add(new MediaSourceDeviceVideos(mock(ContentResolver.class)));
+        testSources.add(new MediaSourceDeviceImages());
+        testSources.add(new MediaSourceDeviceVideos());
 
         final MediaSourceAdapter testAdapter = new MediaSourceAdapter(Robolectric.application, testSources, null);
 

--- a/mediapicker/src/main/java/org/wordpress/mediapicker/MediaItem.java
+++ b/mediapicker/src/main/java/org/wordpress/mediapicker/MediaItem.java
@@ -8,12 +8,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Simple data model to describe media information, including:
- * <ul>
- *     <li>Title</li>
- *     <li>Source</li>
- *     <li>Preview Image</li>
- * </ul>
+ * Simple data model to describe media information. Contains the following data:
+ *  - Tag: Used to store an arbitrary String for implementation specific use and is therefore not
+ *  used by {@link org.wordpress.mediapicker.MediaPickerFragment} to determine behavior.
+ *  - Content Title: Title of the media content.
+ *  - Preview Source: URI to media content preview.
+ *  - Content Source: Direct URI to the media content.
+ *  - Rotation: Specifies the orientation that the media was captured in.
  *
  * Implements {@link android.os.Parcelable} to allow passing via {@link android.content.Intent}'s.
  */
@@ -142,6 +143,8 @@ public class MediaItem implements Parcelable {
 
                         while (parcelData.size() > 0) {
                             String data = parcelData.remove(0);
+                            if (data == null) continue;
+
                             String key = data.substring(0, data.indexOf('='));
                             String value = data.substring(data.indexOf('=') + 1, data.length());
 

--- a/mediapicker/src/main/java/org/wordpress/mediapicker/MediaSourceAdapter.java
+++ b/mediapicker/src/main/java/org/wordpress/mediapicker/MediaSourceAdapter.java
@@ -5,7 +5,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
-import android.widget.ProgressBar;
 
 import com.android.volley.toolbox.ImageLoader;
 
@@ -30,13 +29,13 @@ import java.util.List;
  */
 
 public class MediaSourceAdapter extends BaseAdapter {
-    private final LayoutInflater  mLayoutInflater;
+    private final Context mContext;
     private final ImageLoader.ImageCache mImageCache;
     private final List<MediaSource> mMediaSources;
 
     public MediaSourceAdapter(Context context, List<MediaSource> sources, ImageLoader.ImageCache imageCache) {
         mMediaSources = sources;
-        mLayoutInflater = LayoutInflater.from(context);
+        mContext = context;
         mImageCache = imageCache;
     }
 
@@ -44,7 +43,7 @@ public class MediaSourceAdapter extends BaseAdapter {
         for (MediaSource source : mMediaSources) {
             if (source != null) {
                 source.setListener(listener);
-                source.gather();
+                source.gather(mContext);
             }
         }
     }
@@ -81,11 +80,7 @@ public class MediaSourceAdapter extends BaseAdapter {
         MediaSource itemSource = sourceAtPosition(position);
 
         if (itemSource != null) {
-            if (convertView instanceof ProgressBar) {
-                convertView = null;
-            }
-
-            return itemSource.getView(position - offsetAtPosition(position), convertView, parent, mLayoutInflater, mImageCache);
+            return itemSource.getView(position - offsetAtPosition(position), convertView, parent, LayoutInflater.from(mContext), mImageCache);
         }
 
         return null;

--- a/mediapicker/src/main/java/org/wordpress/mediapicker/MediaUtils.java
+++ b/mediapicker/src/main/java/org/wordpress/mediapicker/MediaUtils.java
@@ -17,7 +17,9 @@ import com.android.volley.toolbox.ImageLoader;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class MediaUtils {
     private static final long FADE_TIME_MS = 250;
@@ -40,20 +42,99 @@ public class MediaUtils {
     }
 
     public static Cursor getMediaStoreThumbnails(ContentResolver contentResolver, String[] columns) {
+        if (contentResolver == null) return null;
         Uri thumbnailUri = MediaStore.Images.Thumbnails.EXTERNAL_CONTENT_URI;
         return MediaStore.Images.Thumbnails.query(contentResolver, thumbnailUri, columns);
     }
 
     public static Cursor getDeviceMediaStoreVideos(ContentResolver contentResolver, String[] columns) {
+        if (contentResolver == null) return null;
         Uri videoUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
         return MediaStore.Video.query(contentResolver, videoUri, columns);
+    }
+
+    public static Map<String, String> getMediaStoreThumbnailData(Cursor thumbnailCursor,
+                                                                 String dataColumnName,
+                                                                 String idColumnName) {
+        final Map<String, String> data = new HashMap<>();
+
+        if (thumbnailCursor != null) {
+            if (thumbnailCursor.moveToFirst()) {
+                do {
+                    int dataColumnIndex = thumbnailCursor.getColumnIndex(dataColumnName);
+                    int imageIdColumnIndex = thumbnailCursor.getColumnIndex(idColumnName);
+
+                    if (dataColumnIndex != -1 && imageIdColumnIndex != -1) {
+                        data.put(thumbnailCursor.getString(imageIdColumnIndex),
+                                 thumbnailCursor.getString(dataColumnIndex));
+                    }
+                } while (thumbnailCursor.moveToNext());
+            }
+
+            thumbnailCursor.close();
+        }
+
+        return data;
+    }
+
+    public static List<MediaItem> createMediaItems(Map<String, String> thumbnailData, Cursor mediaCursor, int type) {
+        final List<MediaItem> mediaItems = new ArrayList<>();
+        final List<String> ids = new ArrayList<>();
+
+        if (mediaCursor != null) {
+            if (mediaCursor.moveToFirst()) {
+                do {
+                    MediaItem newContent = type == BackgroundFetchThumbnail.TYPE_IMAGE ?
+                               getMediaItemFromImageCursor(mediaCursor, thumbnailData) :
+                               getMediaItemFromVideoCursor(mediaCursor, thumbnailData);
+
+                    if (newContent != null && !ids.contains(newContent.getTag())) {
+                        mediaItems.add(newContent);
+                        ids.add(newContent.getTag());
+                    }
+                } while (mediaCursor.moveToNext());
+            }
+
+            mediaCursor.close();
+        }
+
+        return mediaItems;
+    }
+
+    public static void fadeMediaItemImageIntoView(Uri imageSource, ImageLoader.ImageCache cache,
+                                                  ImageView imageView, MediaItem mediaItem,
+                                                  int width, int height, int type) {
+        if (imageSource != null && !imageSource.toString().isEmpty()) {
+            Bitmap imageBitmap = null;
+            if (cache != null) {
+                imageBitmap = cache.getBitmap(imageSource.toString());
+            }
+
+            if (imageBitmap == null) {
+                imageView.setImageResource(R.drawable.media_item_placeholder);
+                BackgroundFetchThumbnail bgDownload =
+                        new MediaUtils.BackgroundFetchThumbnail(imageView,
+                                cache,
+                                type,
+                                width,
+                                height,
+                                mediaItem.getRotation());
+                imageView.setTag(bgDownload);
+                bgDownload.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, imageSource);
+            } else {
+                fadeInImage(imageView, imageBitmap);
+            }
+        } else {
+            imageView.setTag(null);
+            imageView.setImageResource(R.drawable.ic_now_wallpaper_white);
+        }
     }
 
     public static class BackgroundFetchThumbnail extends AsyncTask<Uri, String, Bitmap> {
         public static final int TYPE_IMAGE = 0;
         public static final int TYPE_VIDEO = 1;
 
-        private static final int MAX_ACTIVE_FETCHES_DEFAULT = 24;
+        private static final int MAX_ACTIVE_FETCHES_DEFAULT = 32;
         private static final List<BackgroundFetchThumbnail> sActiveFetches = new ArrayList<>();
 
         private WeakReference<ImageView> mReference;
@@ -160,5 +241,53 @@ public class MediaUtils {
         public void setMaxFetches(int maxFetches) {
             mMaxFetches = maxFetches;
         }
+    }
+
+    private static MediaItem getMediaItemFromVideoCursor(Cursor videoCursor, Map<String, String> thumbnailData) {
+        MediaItem newContent = null;
+
+        int videoIdColumnIndex = videoCursor.getColumnIndex(MediaStore.Video.Media._ID);
+        int videoDataColumnIndex = videoCursor.getColumnIndex(MediaStore.Video.Media.DATA);
+
+        if (videoIdColumnIndex != -1) {
+            newContent = new MediaItem();
+            newContent.setTag(videoCursor.getString(videoIdColumnIndex));
+            newContent.setTitle("");
+
+            if (videoDataColumnIndex != -1) {
+                newContent.setSource(Uri.parse(videoCursor.getString(videoDataColumnIndex)));
+            }
+            if (thumbnailData.containsKey(newContent.getTag())) {
+                newContent.setPreviewSource(Uri.parse(thumbnailData.get(newContent.getTag())));
+            }
+        }
+
+        return newContent;
+    }
+
+    private static MediaItem getMediaItemFromImageCursor(Cursor imageCursor, Map<String, String> thumbnailData) {
+        MediaItem newContent = null;
+
+        int imageIdColumnIndex = imageCursor.getColumnIndex(MediaStore.Images.Media._ID);
+        int imageDataColumnIndex = imageCursor.getColumnIndex(MediaStore.Images.Media.DATA);
+        int imageOrientationColumnIndex = imageCursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION);
+
+        if (imageIdColumnIndex != -1) {
+            newContent = new MediaItem();
+            newContent.setTag(imageCursor.getString(imageIdColumnIndex));
+            newContent.setTitle("");
+
+            if (imageDataColumnIndex != -1) {
+                newContent.setSource(Uri.parse(imageCursor.getString(imageDataColumnIndex)));
+            }
+            if (thumbnailData.containsKey(newContent.getTag())) {
+                newContent.setPreviewSource(Uri.parse(thumbnailData.get(newContent.getTag())));
+            }
+            if (imageOrientationColumnIndex != -1) {
+                newContent.setRotation(imageCursor.getInt(imageOrientationColumnIndex));
+            }
+        }
+
+        return newContent;
     }
 }

--- a/mediapicker/src/main/java/org/wordpress/mediapicker/source/MediaSource.java
+++ b/mediapicker/src/main/java/org/wordpress/mediapicker/source/MediaSource.java
@@ -1,5 +1,6 @@
 package org.wordpress.mediapicker.source;
 
+import android.content.Context;
 import android.os.Parcelable;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -21,7 +22,15 @@ public interface MediaSource extends Parcelable {
      * Interface offered for any class to implement a listener for data set changes.
      */
     public interface OnMediaChange {
+        /**
+         * To be called after all initial {@link org.wordpress.mediapicker.MediaItem}s have been
+         * gathered following a call to {@link #gather(android.content.Context)}.
+         *
+         * @param success
+         * if false an error message will be displayed in lieu of the media views
+         */
         public void onMediaLoaded(boolean success);
+
         /**
          * To be called when new MediaItems have been added to the source.
          *
@@ -54,7 +63,7 @@ public interface MediaSource extends Parcelable {
     }
 
     // Load MediaItem data
-    public void gather();
+    public void gather(Context context);
     // Destroy MediaItem data
     public void cleanup();
     // Can be ignored if no listener is needed

--- a/mediapicker/src/main/java/org/wordpress/mediapicker/source/MediaSourceCaptureImage.java
+++ b/mediapicker/src/main/java/org/wordpress/mediapicker/source/MediaSourceCaptureImage.java
@@ -51,7 +51,7 @@ public class MediaSourceCaptureImage implements MediaSource, Camera.PictureCallb
     }
 
     @Override
-    public void gather() {
+    public void gather(Context context) {
 
     }
 

--- a/mediapicker/src/main/java/org/wordpress/mediapicker/source/MediaSourceDeviceVideos.java
+++ b/mediapicker/src/main/java/org/wordpress/mediapicker/source/MediaSourceDeviceVideos.java
@@ -1,10 +1,7 @@
 package org.wordpress.mediapicker.source;
 
-import android.content.ContentResolver;
 import android.database.Cursor;
-import android.graphics.Bitmap;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Parcel;
 import android.provider.MediaStore;
 import android.view.LayoutInflater;
@@ -20,54 +17,32 @@ import org.wordpress.mediapicker.MediaUtils;
 import org.wordpress.mediapicker.R;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class MediaSourceDeviceVideos implements MediaSource {
-    private static final String[] VIDEO_QUERY_COLUMNS = { MediaStore.Video.Media._ID,
+public class MediaSourceDeviceVideos extends MediaSourceDeviceImages {
+    private static final String[] VIDEO_QUERY_COLUMNS = {
+            MediaStore.Video.Media._ID,
             MediaStore.Video.Media.DATA };
-    private static final String[] THUMBNAIL_QUERY_COLUMNS = { MediaStore.Video.Media._ID,
+    private static final String[] THUMBNAIL_QUERY_COLUMNS = {
+            MediaStore.Video.Media._ID,
             MediaStore.Video.Media.DATA,
             MediaStore.Video.Media.DATE_TAKEN };
 
-    private ContentResolver mContentResolver;
-    private List<MediaItem> mMediaItems;
-
-    public MediaSourceDeviceVideos() {
-        mContentResolver = null;
-    }
-
-    private void setMediaItems(List<MediaItem> mediaItems) {
-        mMediaItems = mediaItems;
-    }
-
-    public MediaSourceDeviceVideos(final ContentResolver contentResolver) {
-        mContentResolver = contentResolver;
-        createMediaItems();
-    }
-
     @Override
-    public void gather() {
-    }
+    protected List<MediaItem> createMediaItems() {
+        Cursor thumbnailCursor = MediaUtils.getDeviceMediaStoreVideos(mContext.getContentResolver(),
+                THUMBNAIL_QUERY_COLUMNS);
+        Map<String, String> thumbnailData = MediaUtils.getMediaStoreThumbnailData(thumbnailCursor,
+                MediaStore.Video.Media.DATA,
+                MediaStore.Video.Media._ID);
 
-    @Override
-    public void cleanup() {
-    }
-
-    @Override
-    public void setListener(final OnMediaChange listener) {
-        // Ignored
-    }
-
-    @Override
-    public int getCount() {
-        return mMediaItems.size();
-    }
-
-    @Override
-    public MediaItem getMedia(int position) {
-        return mMediaItems.get(position);
+        return MediaUtils.createMediaItems(thumbnailData,
+                MediaStore.Images.Media.query(mContext.getContentResolver(),
+                MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
+                VIDEO_QUERY_COLUMNS, null, null,
+                MediaStore.MediaColumns.DATE_MODIFIED + " DESC"),
+                MediaUtils.BackgroundFetchThumbnail.TYPE_VIDEO);
     }
 
     @Override
@@ -76,7 +51,7 @@ public class MediaSourceDeviceVideos implements MediaSource {
             convertView = inflater.inflate(R.layout.media_item_video, parent, false);
         }
 
-        if (convertView != null) {
+        if (convertView != null && position < mMediaItems.size()) {
             final MediaItem mediaItem = mMediaItems.get(position);
             final Uri imageSource = mediaItem.getPreviewSource();
 
@@ -91,119 +66,20 @@ public class MediaSourceDeviceVideos implements MediaSource {
                         public boolean onPreDraw() {
                             int width = imageView.getWidth();
                             int height = imageView.getHeight();
-                            setImage(imageSource, cache, imageView, mediaItem, width, height);
+                            MediaUtils.fadeMediaItemImageIntoView(imageSource, cache, imageView, mediaItem,
+                                    width, height, MediaUtils.BackgroundFetchThumbnail.TYPE_VIDEO);
                             imageView.getViewTreeObserver().removeOnPreDrawListener(this);
                             return true;
                         }
                     });
                 } else {
-                    setImage(imageSource, cache, imageView, mediaItem, width, height);
+                    MediaUtils.fadeMediaItemImageIntoView(imageSource, cache, imageView, mediaItem,
+                            width, height, MediaUtils.BackgroundFetchThumbnail.TYPE_VIDEO);
                 }
             }
         }
 
         return convertView;
-    }
-
-    private void setImage(Uri imageSource, ImageLoader.ImageCache cache, ImageView imageView, MediaItem mediaItem, int width, int height) {
-        if (imageSource != null) {
-            Bitmap imageBitmap = null;
-            if (cache != null) {
-                imageBitmap = cache.getBitmap(imageSource.toString());
-            }
-
-            if (imageBitmap == null) {
-                imageView.setImageResource(R.drawable.media_item_placeholder);
-                MediaUtils.BackgroundFetchThumbnail bgDownload =
-                        new MediaUtils.BackgroundFetchThumbnail(imageView,
-                                cache,
-                                MediaUtils.BackgroundFetchThumbnail.TYPE_VIDEO,
-                                width,
-                                height,
-                                mediaItem.getRotation());
-                imageView.setTag(bgDownload);
-                bgDownload.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, imageSource);
-            } else {
-                MediaUtils.fadeInImage(imageView, imageBitmap);
-            }
-        } else {
-            imageView.setTag(null);
-            imageView.setImageResource(R.drawable.ic_now_wallpaper_white);
-        }
-    }
-
-    @Override
-    public boolean onMediaItemSelected(MediaItem mediaItem, boolean selected) {
-        return !selected;
-    }
-
-    private void createMediaItems() {
-        final List<String> videoIds = new ArrayList<>();
-        final Map<String, String> thumbnailData = getVideoThumbnailData();
-        mMediaItems = new ArrayList<>();
-
-        Uri videoUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-        Cursor cursor = MediaStore.Images.Media.query(mContentResolver, videoUri, VIDEO_QUERY_COLUMNS, null,
-                null, MediaStore.MediaColumns.DATE_MODIFIED + " DESC");
-
-        if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                do {
-                    MediaItem newContent = getMediaItemFromCursor(cursor, thumbnailData);
-
-                    if (newContent != null && !videoIds.contains(newContent.getTag())) {
-                        mMediaItems.add(newContent);
-                        videoIds.add(newContent.getTag());
-                    }
-                } while (cursor.moveToNext());
-            }
-
-            cursor.close();
-        }
-    }
-
-    private Map<String, String> getVideoThumbnailData() {
-        final Map<String, String> data = new HashMap<>();
-        Cursor thumbnailCursor = MediaUtils.getDeviceMediaStoreVideos(mContentResolver, THUMBNAIL_QUERY_COLUMNS);
-
-        if (thumbnailCursor != null) {
-            if (thumbnailCursor.moveToFirst()) {
-                do {
-                    int videoIdColumnIndex = thumbnailCursor.getColumnIndex(MediaStore.Video.Media._ID);
-                    int thumbnailColumnIndex = thumbnailCursor.getColumnIndex(MediaStore.Video.Media.DATA);
-
-                    if (thumbnailColumnIndex != -1 && videoIdColumnIndex != -1) {
-                        data.put(thumbnailCursor.getString(videoIdColumnIndex), thumbnailCursor.getString(thumbnailColumnIndex));
-                    }
-                } while (thumbnailCursor.moveToNext());
-            }
-
-            thumbnailCursor.close();
-        }
-
-        return data;
-    }
-
-    private MediaItem getMediaItemFromCursor(Cursor videoCursor, Map<String, String> thumbnailData) {
-        MediaItem newContent = null;
-
-        int videoIdColumnIndex = videoCursor.getColumnIndex(MediaStore.Video.Media._ID);
-        int videoDataColumnIndex = videoCursor.getColumnIndex(MediaStore.Video.Media.DATA);
-
-        if (videoIdColumnIndex != -1) {
-            newContent = new MediaItem();
-            newContent.setTag(videoCursor.getString(videoIdColumnIndex));
-            newContent.setTitle("");
-
-            if (videoDataColumnIndex != -1) {
-                newContent.setSource(Uri.parse(videoCursor.getString(videoDataColumnIndex)));
-            }
-            if (thumbnailData.containsKey(newContent.getTag())) {
-                newContent.setPreviewSource(Uri.parse(thumbnailData.get(newContent.getTag())));
-            }
-        }
-
-        return newContent;
     }
 
     /**
@@ -215,15 +91,13 @@ public class MediaSourceDeviceVideos implements MediaSource {
                 public MediaSourceDeviceVideos createFromParcel(Parcel in) {
                     List<MediaItem> parcelData = new ArrayList<>();
                     in.readTypedList(parcelData, MediaItem.CREATOR);
+                    MediaSourceDeviceVideos newItem = new MediaSourceDeviceVideos();
 
                     if (parcelData.size() > 0) {
-                        MediaSourceDeviceVideos newItem = new MediaSourceDeviceVideos();
                         newItem.setMediaItems(parcelData);
-
-                        return newItem;
                     }
 
-                    return null;
+                    return newItem;
                 }
 
                 public MediaSourceDeviceVideos[] newArray(int size) {
@@ -238,8 +112,6 @@ public class MediaSourceDeviceVideos implements MediaSource {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        if (mMediaItems != null) {
-            dest.writeTypedList(mMediaItems);
-        }
+        dest.writeTypedList(mMediaItems);
     }
 }

--- a/mediapicker/src/main/res/drawable/media_item_placeholder.xml
+++ b/mediapicker/src/main/res/drawable/media_item_placeholder.xml
@@ -4,6 +4,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:drawable="@color/grey" />
+        android:drawable="@color/light_blue" />
 
 </selector>

--- a/mediapicker/src/main/res/layout/media_picker_fragment.xml
+++ b/mediapicker/src/main/res/layout/media_picker_fragment.xml
@@ -11,6 +11,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="@dimen/empty_view_text_size"
+        android:gravity="center"
         android:layout_gravity="center" />
 
     <GridView

--- a/mediapicker/src/main/res/values/colors.xml
+++ b/mediapicker/src/main/res/values/colors.xml
@@ -4,5 +4,6 @@
 
     <!-- Used as the default background color -->
     <color name="grey">#999999</color>
+    <color name="light_blue">#a9f9f9</color>
 
 </resources>

--- a/mediapicker/src/main/res/values/strings.xml
+++ b/mediapicker/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
 
     <string name="fetching_media">Fetching media</string>
     <string name="no_media_sources">No media sources set.</string>
-    <string name="no_media">No media. Why not take a picture?</string>
+    <string name="no_media">No media. Why not take capture some?</string>
     <string name="error_fetching_media">Error gathering media from source</string>
 
 </resources>

--- a/sample/src/main/java/org/wordpress/mediapickersample/SampleActivity.java
+++ b/sample/src/main/java/org/wordpress/mediapickersample/SampleActivity.java
@@ -74,11 +74,11 @@ public class SampleActivity extends Activity
      */
     private void initializeTabs() {
         ArrayList<MediaSource> imageSources = new ArrayList<>();
-        imageSources.add(new MediaSourceDeviceImages(getContentResolver()));
+        imageSources.add(new MediaSourceDeviceImages());
         mMediaPickerAdapter.addTab(imageSources, TAB_TITLE_IMAGES);
 
         ArrayList<MediaSource> videoSources = new ArrayList<>();
-        videoSources.add(new MediaSourceDeviceVideos(getContentResolver()));
+        videoSources.add(new MediaSourceDeviceVideos());
         mMediaPickerAdapter.addTab(videoSources, TAB_TITLE_VIDEOS);
 
         ArrayList<MediaSource> emptySources = new ArrayList<>();

--- a/sample/src/main/java/org/wordpress/mediapickersample/source/MediaSourceEmpty.java
+++ b/sample/src/main/java/org/wordpress/mediapickersample/source/MediaSourceEmpty.java
@@ -1,5 +1,6 @@
 package org.wordpress.mediapickersample.source;
 
+import android.content.Context;
 import android.os.Parcel;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -18,7 +19,7 @@ public class MediaSourceEmpty implements MediaSource {
     private OnMediaChange mListener;
 
     @Override
-    public void gather() {
+    public void gather(Context context) {
         if (mListener != null) {
             mListener.onMediaLoaded(true);
         }

--- a/sample/src/main/java/org/wordpress/mediapickersample/source/MediaSourceError.java
+++ b/sample/src/main/java/org/wordpress/mediapickersample/source/MediaSourceError.java
@@ -1,5 +1,6 @@
 package org.wordpress.mediapickersample.source;
 
+import android.content.Context;
 import android.os.Parcel;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -18,7 +19,7 @@ public class MediaSourceError implements MediaSource {
     private OnMediaChange mListener;
 
     @Override
-    public void gather() {
+    public void gather(Context context) {
         if (mListener != null) {
             mListener.onMediaLoaded(false);
         }


### PR DESCRIPTION
Cleaning up media sources on fragment destruction, adapter state fixes.

Vastly simplifying video and image media sources.

Offloading duplicate work to MediaUtils and MediaSourceDeviceVideo now inherits from MediaSourceDeviceImages.

Updating MediaSource interface to add Context to the gather method. This will allow MediaSources to utilize resources and other utilities.
