### PR TITLE
Limiting the number of background thumbnail fetches to 16.

### DIFF
--- a/mediapicker/src/main/java/org/wordpress/mediapicker/MediaPickerFragment.java
+++ b/mediapicker/src/main/java/org/wordpress/mediapicker/MediaPickerFragment.java
@@ -581,12 +581,14 @@ public class MediaPickerFragment extends Fragment
      * view will be hidden. Otherwise the empty view will be hidden and the adapter view presented.
      */
     private void toggleEmptyVisibility() {
-        if (mAdapter.getCount() == 0) {
-            mEmptyView.setVisibility(View.VISIBLE);
-            mAdapterView.setVisibility(View.GONE);
-        } else {
-            mEmptyView.setVisibility(View.GONE);
-            mAdapterView.setVisibility(View.VISIBLE);
+        int empty = (mAdapter != null && mAdapter.getCount() == 0) ? View.VISIBLE : View.GONE;
+        int adapter = (mAdapter != null && mAdapter.getCount() == 0) ? View.GONE : View.VISIBLE;
+
+        if (mEmptyView != null) {
+            mEmptyView.setVisibility(empty);
+        }
+        if (mAdapterView != null) {
+            mAdapterView.setVisibility(adapter);
         }
     }
 

--- a/mediapicker/src/main/java/org/wordpress/mediapicker/MediaUtils.java
+++ b/mediapicker/src/main/java/org/wordpress/mediapicker/MediaUtils.java
@@ -345,10 +345,18 @@ public class MediaUtils {
             newContent.setTitle("");
 
             if (imageDataColumnIndex != -1) {
-                newContent.setSource(Uri.parse(imageCursor.getString(imageDataColumnIndex)));
+                String imageSource = imageCursor.getString(imageDataColumnIndex);
+                if (imageSource == null) {
+                    return null;
+                }
+                newContent.setSource(Uri.parse(imageSource));
             }
             if (thumbnailData.containsKey(newContent.getTag())) {
-                newContent.setPreviewSource(Uri.parse(thumbnailData.get(newContent.getTag())));
+                String thumbnailSource = thumbnailData.get(newContent.getTag());
+                if (thumbnailSource == null) {
+                    return null;
+                }
+                newContent.setPreviewSource(Uri.parse(thumbnailSource));
             }
             if (imageOrientationColumnIndex != -1) {
                 newContent.setRotation(imageCursor.getInt(imageOrientationColumnIndex));

--- a/mediapicker/src/main/java/org/wordpress/mediapicker/source/MediaSourceCaptureImage.java
+++ b/mediapicker/src/main/java/org/wordpress/mediapicker/source/MediaSourceCaptureImage.java
@@ -142,7 +142,7 @@ public class MediaSourceCaptureImage implements MediaSource, Camera.PictureCallb
                                 height,
                                 mediaItem.getRotation());
                 imageView.setTag(bgDownload);
-                bgDownload.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, imageSource);
+                bgDownload.executeWithLimit(imageSource);
             } else {
                 MediaUtils.fadeInImage(imageView, imageBitmap);
             }


### PR DESCRIPTION
Adding too many executions can result in a RejectedExecutionException pretty quickly. By using executeWithLimit new executions are deferred until an existing one completes.

Addresses #13 and a [cousin issue](https://github.com/wordpress-mobile/WordPress-Android/issues/2522) in WordPress for Android.
