### PR TITLE
Multi-select now shows action mode buttons

### DIFF
--- a/mediapicker/src/main/java/org/wordpress/mediapicker/MediaPickerFragment.java
+++ b/mediapicker/src/main/java/org/wordpress/mediapicker/MediaPickerFragment.java
@@ -239,7 +239,6 @@ public class MediaPickerFragment extends Fragment
     public boolean onCreateActionMode(ActionMode mode, Menu menu) {
         mode.setTitle(getActivity().getTitle());
         getActivity().onActionModeStarted(mode);
-
         inflateActionModeMenu(menu);
 
         return true;

--- a/mediapicker/src/main/java/org/wordpress/mediapicker/MediaPickerFragment.java
+++ b/mediapicker/src/main/java/org/wordpress/mediapicker/MediaPickerFragment.java
@@ -240,23 +240,15 @@ public class MediaPickerFragment extends Fragment
         mode.setTitle(getActivity().getTitle());
         getActivity().onActionModeStarted(mode);
 
+        inflateActionModeMenu(menu);
+
         return true;
     }
 
     @Override
     public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
         notifyMediaSelectionStarted();
-
         mConfirmed = false;
-
-        MenuInflater menuInflater = getActivity().getMenuInflater();
-
-        if (mActionModeMenu != -1) {
-            menuInflater.inflate(mActionModeMenu, menu);
-            addSelectionConfirmationButtonMenuItem(menu);
-        } else {
-            menuInflater.inflate(R.menu.media_picker_action_mode, menu);
-        }
 
         return true;
     }
@@ -560,6 +552,23 @@ public class MediaPickerFragment extends Fragment
         mAdapterView.setOnItemClickListener(this);
         mAdapterView.setChoiceMode(AbsListView.CHOICE_MODE_MULTIPLE_MODAL);
         mAdapterView.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
+    }
+
+    /**
+     * Inflates custom mActionModeMenu if set, otherwise inflates default media_picker_action_mode.
+     *
+     * @param menu
+     * the menu to inflate to
+     */
+    private void inflateActionModeMenu(Menu menu) {
+        MenuInflater menuInflater = getActivity().getMenuInflater();
+
+        if (mActionModeMenu != -1) {
+            menuInflater.inflate(mActionModeMenu, menu);
+            addSelectionConfirmationButtonMenuItem(menu);
+        } else {
+            menuInflater.inflate(R.menu.media_picker_action_mode, menu);
+        }
     }
 
     /**

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -21,6 +21,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.0.0'
+    compile 'com.android.support:appcompat-v7:22.2.1'
     compile project(':mediapicker')
 }

--- a/sample/src/main/java/org/wordpress/mediapickersample/SampleActivity.java
+++ b/sample/src/main/java/org/wordpress/mediapickersample/SampleActivity.java
@@ -1,6 +1,5 @@
 package org.wordpress.mediapickersample;
 
-import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.ActionBar;
@@ -8,6 +7,7 @@ import android.os.Bundle;
 
 import android.support.v13.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
+import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.widget.Toast;
 
@@ -27,7 +27,7 @@ import java.util.List;
  * Demonstrates the intended usage of the MediaPicker-Android library.
  */
 
-public class SampleActivity extends Activity
+public class SampleActivity extends AppCompatActivity
                             implements MediaPickerFragment.OnMediaSelected {
     private static final String TAB_TITLE_IMAGES = "Images";
     private static final String TAB_TITLE_VIDEOS = "Videos";


### PR DESCRIPTION
Resolves #25

Because the app was using `AppCompatActivity`, I had to switch the inflation of the menu from `onPrepareActionMode` to `onCreateActionMode`

To test:
1. Go to blog posts and create a new post.
2. Click the 'Multi-select with the new picker' option for adding an image and press-and-hold on an image.
3. There should be a Checkbox on the top right of the action bar now that allows you to import the image.

Needs review: @aforcier 
